### PR TITLE
feat: add region as default longhand

### DIFF
--- a/visual-shorthands.el
+++ b/visual-shorthands.el
@@ -434,8 +434,12 @@ Also see `visual-shorthands-remove-mapping' and
      (add-hook 'minibuffer-setup-hook
                #'visual-shorthands--preview-minibuffer-setup)
      (unwind-protect
-         (let* ((longhand-input
-                 (read-string "Longhand prefix: "))
+         (let* ((default-longhand
+                  (when (use-region-p)
+                    (buffer-substring-no-properties
+                     (region-beginning) (region-end))))
+                (longhand-input
+                 (read-string "Longhand prefix: " default-longhand))
                 (shorthand-input
                  (progn
                    (visual-shorthands--preview-cleanup)


### PR DESCRIPTION
- This allows us to use region as default longhand. Invoking the command `M-x visual-shorthands-add-mapping` on an active region inserts it as the default longhand.

I'm not sure if this helps anyone, but its a simple add and it is surely helpful to me.